### PR TITLE
[FE-#8] splash 화면 구현

### DIFF
--- a/lib/features/splash/presentation/pages/splash_page.dart
+++ b/lib/features/splash/presentation/pages/splash_page.dart
@@ -6,7 +6,6 @@ class SplashPage extends StatefulWidget {
   const SplashPage({super.key});
 
   @override
-  // ignore: library_private_types_in_public_api
   _SplashPageState createState() => _SplashPageState();
 }
 
@@ -51,34 +50,41 @@ class _SplashPageState extends State<SplashPage>
       body: Center(
         child: Row(
           mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.end,
           children: [
             // 왼쪽 텍스트: "바쁜 일상에"
             const Text(
               "바쁜 일상에",
               style: TextStyle(
                   fontSize: 18,
-                  fontWeight: FontWeight.bold,
+                  fontWeight: FontWeight.w900,
+                  fontFamily: 'Pretendard',
                   color: Colors.white),
             ),
-            const SizedBox(width: 10), // 간격 추가
+            const SizedBox(width: 0), // 간격 추가
 
-            // 로고 아이콘 (애니메이션 적용)
-            FadeTransition(
-              opacity: _animation, // 투명도 애니메이션 적용
-              child: const Icon(
-                Icons.cloud, // ☁️ 아이콘 변경
-                size: 60,
-                color: Colors.white,
+            // 로고 이미지 (애니메이션 적용, 위치 살짝 올리기)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 5.0), // 아이콘을 살짝 위로 이동
+              child: FadeTransition(
+                opacity: _animation, // 투명도 애니메이션 적용
+                child: Image.asset(
+                  'assets/icons/logo_w.png',
+                  width: 80,
+                  height: 80,
+                  fit: BoxFit.contain,
+                ),
               ),
             ),
-            const SizedBox(width: 10), // 간격 추가
+            const SizedBox(width: 0), // 간격 추가
 
             // 오른쪽 텍스트: "쉼표를 찍다"
             const Text(
               "쉼표를 찍다",
               style: TextStyle(
                   fontSize: 18,
-                  fontWeight: FontWeight.bold,
+                  fontWeight: FontWeight.w900,
+                  fontFamily: 'Pretendard',
                   color: Colors.white),
             ),
           ],


### PR DESCRIPTION
## 🛰️ Issue Number
#8 

## 🪐 작업 내용
  📌 구현한 주요 작업
  1. SplashPage UI 설계
    Scaffold + Column을 사용하여 텍스트 + 로고 정렬
    "바쁜 일상에 쉼표를 찍다" 텍스트를 왼쪽 배치
    쉼표 이미지를 중앙에 배치
    텍스트는 항상 표시되지만, 로고(아이콘)는 그라데이션 애니메이션을 적용

  2. 애니메이션 효과 추가
    AnimatedOpacity를 사용하여 로고가 서서히 나타나는 효과 적용
    애니메이션 지속 시간: 1.5초
    애니메이션이 완료되면 메인 페이지로 자동 이동

  3. 일정 시간 후 자동 전환
    Future.delayed(Duration(seconds: 2)) 사용
    2초 후 Navigator.pushReplacement를 이용해 MainPage로 이동
    pushReplacement: 스플래시 페이지를 스택에서 제거하여 뒤로 가기 시 보이지 않도록 함


## 📚 Reference

## ✅ Check List
- [X] 코드가 정상적으로 컴파일되나요?
- [X] 테스트 코드를 통과했나요?
- [X] merge할 브랜치의 위치를 확인했나요?
- [X] Label을 지정했나요?
